### PR TITLE
fixed misspelled allot

### DIFF
--- a/coding-with-eyes-closed/src/01-0-introduction.md
+++ b/coding-with-eyes-closed/src/01-0-introduction.md
@@ -27,7 +27,7 @@ The book also contains exercises, to get you up and running.
 
 ### How you should read this book.
 
-You have to learn allot of things when you lose your sight practically and emotionally.
+You have to learn a lot of things when you lose your sight practically and emotionally.
 That is why I made a very efficient way to read this book.
 
 To follow the fastest path possible to code with eyes closed, go to [the cheat sheet section](https://codingwitheyesclosed.com/09-0-cheat-sheet.html) and read it and follow the advice.

--- a/coding-with-eyes-closed/src/03-0-start.md
+++ b/coding-with-eyes-closed/src/03-0-start.md
@@ -3,7 +3,7 @@
 That you're reading this book is probably because of a accident or a disease. 
 I am sorry for you.
 Everything is going to be just fine. 
-There is allot possible and there are allot of accessible tools. 
+There is a lot possible and there are a lot of accessible tools. 
 I will talk briefly about operating systems, screen readers and braille. 
 Ready? Lets go!
 

--- a/coding-with-eyes-closed/src/03-2-screen-reader.md
+++ b/coding-with-eyes-closed/src/03-2-screen-reader.md
@@ -46,7 +46,7 @@ Feel free to experiment, you'll have to figure out what works for you. Here are 
 #### Windows
 
 If you are on windows, use [NVDA](https://www.nvaccess.org/download/). It is fast, open source and free.
-You have other options, but they are slow and too complex and crash allot. NVDA is not only free, it is better then the payed options.
+You have other options, but they are slow and too complex and crash a lot. NVDA is not only free, it is better then the payed options.
 
 #### Mac
 

--- a/coding-with-eyes-closed/src/04-1-terminal.md
+++ b/coding-with-eyes-closed/src/04-1-terminal.md
@@ -22,7 +22,7 @@ If that string is read to us, we hear something like:
 OS: macOS 13.4.1 22F82 arm64:MMMMMMMMMMMMMMMMMMMMMMMM: DE: Aqua .MMMMMMMMMMMMMMMMMMMMMMMMX. WM: Quartz Compositor kMMMMMMMMMMMMMMMMMMMMMMMMWd.
 ```
 
-There is allot of garbage in this string and we do not know how to filter it.
+There is a lot of garbage in this string and we do not know how to filter it.
 
 Here is another example: we want to know the file permissions of a file called ```zellij.md```. 
 We know it is in our home directory so we run the the following command:
@@ -34,7 +34,7 @@ ls -la
 First all other files are read before the file that starts with the z is read. 
 Now we have to wait and here all other permissions before we here the file we need.
 
-I believe this is fixable by adding flags to the ls commands to filter it or piping the output in another cli that can filter only that specific line but it costs allot of time because you need to think how you are going to filter that string to find what you need.
+I believe this is fixable by adding flags to the ls commands to filter it or piping the output in another cli that can filter only that specific line but it costs a lot of time because you need to think how you are going to filter that string to find what you need.
 Visual people would only do that with strings that are longer then 100 lines, but we need a filter with 10 and that is time consuming.
 
 You can find a workaround but it does not feel natural.

--- a/coding-with-eyes-closed/src/04-3-websites.md
+++ b/coding-with-eyes-closed/src/04-3-websites.md
@@ -24,7 +24,7 @@ Then they think, Ohh this is going quite well! Lets make a website!
 
 But then they should center a image in a div and they are googeling from sunrise to sunset combining all sorts of copy pasta answers from stack overflow without knowing what actually happens or what it means.
 
-This is what allot of people do, coders laugh about a how to center div css joke and they go on with their stupid google everything together mentality.
+This is what a lot of people do, coders laugh about a how to center div css joke and they go on with their stupid google everything together mentality.
 
 If you want to learn css, read a book about it and then learn by doing.
 
@@ -83,5 +83,5 @@ Bangs are shortcuts for the search-engine.
 Chat bots such as [chat gpt](https://openai.com/chatgpt) can boost your productivity significantly.
 Chat bots can scrape information from websites and format it in such a way that it can save you many minutes otherwise spent on googling.
 
-Those where my tips. We've covered allot. The next chapter is the last technical chapter, we will talk about programming languages.
+Those where my tips. We've covered a lot. The next chapter is the last technical chapter, we will talk about programming languages.
 Ready? Lets go!

--- a/coding-with-eyes-closed/src/05-2-dts.md
+++ b/coding-with-eyes-closed/src/05-2-dts.md
@@ -115,7 +115,7 @@ Making scalable products is hard with these languages.
 Especially if you are coding with eyes closed.
 
 Of course, type system is not everything.
-The C language has static types but is not memory save, so you may have to deal with allot of memory bugs that are hard to fix.
+The C language has static types but is not memory save, so you may have to deal with a lot of memory bugs that are hard to fix.
 So consider your options before you learn a new language.
 Error messages are important.
 

--- a/coding-with-eyes-closed/src/05-3-test.md
+++ b/coding-with-eyes-closed/src/05-3-test.md
@@ -9,7 +9,7 @@ A visual impaired coder maybe makes a mistake in 1 of 3 functions.
 
 But whatever your skill level may be, you make mistakes. Their are functions that do not behave as you wish they did.
 Good coders compensate their mistakes with unit tests. 
-Because good coders do not make so many mistakes as we do, they do not depend on tests so much as we do so allot of people skip them.
+Because good coders do not make so many mistakes as we do, they do not depend on tests so much as we do so a lot of people skip them.
 
 Here is where we as visual impaired coders can turn their disadvantage (introducing more bugs) in to a advantage.
 We need our tests in order to work. 

--- a/coding-with-eyes-closed/src/06-1-energy-slow.md
+++ b/coding-with-eyes-closed/src/06-1-energy-slow.md
@@ -25,7 +25,7 @@ In the beginning I was very slow too. I just wrote like 5 lines a day. Visualizi
 Take a break now and then.
 If you have partial sight, it is okay to take a power nap.
 
-For me buying a new monitor helped allot with energie. 
+For me buying a new monitor helped a lot with energie. 
 I bought a monitor with high contrast and I high DPI so that the text is sharp and easy to read.
 
 The important thing is that you should not compare yourself too much with sighted people.

--- a/coding-with-eyes-closed/src/06-2-too-hard.md
+++ b/coding-with-eyes-closed/src/06-2-too-hard.md
@@ -3,7 +3,7 @@
 I really doubted if coding with eyes closed was a thing that would work for me.
 Luckily I grinded until I could code with eyes closed and I am very happy that I can make whatever I want.
 
-Coding is still allot of fun with eyes closed. 
+Coding is still a lot of fun with eyes closed. 
 For me the fun part is coming up with solutions to problems.
 That is a game that you play in your mind. Not on a screen.
 

--- a/coding-with-eyes-closed/src/07-3-0-github.md
+++ b/coding-with-eyes-closed/src/07-3-0-github.md
@@ -1,5 +1,5 @@
 # GitHub
 
-Github is used allot, so you better know how to use it.
+Github is used a lot, so you better know how to use it.
 
 Feel free to use gitlab or another hosting provider instead of github.


### PR DESCRIPTION
The term allot is quite often used but has another meaning than 'a lot'[^1].

[^1]: https://www.grammarly.com/blog/a-lot-alot-allot/